### PR TITLE
Target Theme Option

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import {
   pullLiveTheme,
   cleanRemoteFiles,
   pushUnpublishedTheme,
+  pushTargetTheme,
   generateThemeNameForEnv
 } from './utils'
 
@@ -15,6 +16,9 @@ async function run(): Promise<void> {
       trimWhitespace: true
     })
 
+    // Add new optional input for duplicating from Prod to an existing theme
+    const targetThemeId: string = core.getInput('theme')
+
     const env: string = core.getInput('env', {
       required: true,
       trimWhitespace: true
@@ -23,12 +27,21 @@ async function run(): Promise<void> {
     await mkdirP(TEMP_FOLDER)
 
     await pullLiveTheme(store, TEMP_FOLDER)
-    const themeID = await pushUnpublishedTheme(
-      store,
-      TEMP_FOLDER,
-      generateThemeNameForEnv(env)
-    )
-    core.setOutput('themeId', themeID)
+    if (targetThemeId) {
+      core.setOutput('themeId', targetThemeId)
+      await pushTargetTheme(
+        targetThemeId,
+        store,
+        TEMP_FOLDER
+      )
+    } else {
+      const themeID = await pushUnpublishedTheme(
+        store,
+        TEMP_FOLDER,
+        generateThemeNameForEnv(env)
+      )
+      core.setOutput('themeId', themeID)
+    }
   } catch (error) {
     if (error instanceof Error) core.setFailed(error.message)
   } finally {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,6 +74,18 @@ export const pushUnpublishedTheme = async (
   return themeID
 }
 
+export const pushTargetTheme = async (
+  theme: string,
+  store: string,
+  folder: string
+): Promise<string> => {
+  await execShellCommand(
+    `shopify theme push --theme ${theme} --path ${folder} --store ${store} --unpublished --ignore ${CONTEXT_BASED_TEMPLATE_REGEX} --json`
+  )
+  debug(`Push to existing theme: ${theme}`)
+  return theme
+}
+
 // Patterh for name: [{env}] Latest Snapshot {date is in format MM.DD.YY}
 export const generateThemeNameForEnv = (env: string): string => {
   const date = new Date()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,7 +80,7 @@ export const pushTargetTheme = async (
   folder: string
 ): Promise<string> => {
   await execShellCommand(
-    `shopify theme push --theme ${theme} --path ${folder} --store ${store} --unpublished --ignore ${CONTEXT_BASED_TEMPLATE_REGEX} --json`
+    `shopify theme push --theme ${theme} --path ${folder} --store ${store} --ignore ${CONTEXT_BASED_TEMPLATE_REGEX} --json`
   )
   debug(`Push to existing theme: ${theme}`)
   return theme


### PR DESCRIPTION
## Updates
- Add alternative function and option for pushing to an existing theme

## Why
- This would allow us to create an optional input on the "Duplicate theme" step in deployment workflows so that instead of duplicating the live theme to a a new unpublished theme, we could duplicate the theme overwrite an existing theme. This would be useful for creating a QA theme that can be constantly updated with Prod's JSON.